### PR TITLE
Use kube-vip IP for cluster nodes to join

### DIFF
--- a/roles/install/tasks/main.yml
+++ b/roles/install/tasks/main.yml
@@ -74,13 +74,13 @@
 
 - name: Determine cluster k3s init server
   ansible.builtin.set_fact:
-    k3s_install_init_server: "{{ ansible_host }}"
+    k3s_init_server: "{{ install_lb_ip | ternary(install_lb_ip, ansible_host) }}"
   run_once: true
   when: inventory_hostname in groups[install_controller_group]
 
 - name: Ensure cluster is initialized
   ansible.builtin.wait_for:
-    host: "{{ k3s_install_init_server }}"
+    host: "{{ k3s_init_server }}"
     port: 6443
     state: started
     timeout: 5
@@ -95,7 +95,7 @@
 - name: Initialize cluster on k3s init server
   run_once: true
   when: cluster_initialized.changed # noqa: no-handler
-  delegate_to: "{{ k3s_install_init_server }}"
+  delegate_to: "{{ k3s_init_server }}"
   block:
     - name: Ensure init config
       ansible.builtin.template:
@@ -133,7 +133,7 @@
 
     - name: Ensure cluster is initialized
       ansible.builtin.wait_for:
-        host: "{{ k3s_install_init_server }}"
+        host: "{{ k3s_init_server }}"
         port: 6443
         state: started
         timeout: 300
@@ -142,7 +142,7 @@
   ansible.builtin.slurp:
     src: /var/lib/rancher/k3s/server/node-token
   run_once: true
-  delegate_to: "{{ k3s_install_init_server }}"
+  delegate_to: "{{ k3s_init_server }}"
   register: node_token
 
 - name: Set token

--- a/roles/install/tasks/main.yml
+++ b/roles/install/tasks/main.yml
@@ -95,7 +95,7 @@
 - name: Initialize cluster on k3s init server
   run_once: true
   when: cluster_initialized.changed # noqa: no-handler
-  delegate_to: "{{ k3s_init_server }}"
+  delegate_to: "{{ ansible_host }}"
   block:
     - name: Ensure init config
       ansible.builtin.template:

--- a/roles/install/templates/config/default.yaml.j2
+++ b/roles/install/templates/config/default.yaml.j2
@@ -38,7 +38,7 @@ node-taint:
 {% for taint in install_taints %}
   - {{ taint }}
 {% endfor %}
-server: https://{{ k3s_install_init_server }}:{{ install_https_port }}
+server: https://{{ k3s_init_server }}:{{ install_https_port }}
 {% if k3s_install_token is defined %}
 token: {{ k3s_install_token }}
 {% endif %}

--- a/roles/uninstall/handlers/main.yml
+++ b/roles/uninstall/handlers/main.yml
@@ -1,2 +1,6 @@
+# code: language=ansible
 ---
 # handlers file for uninstall
+- name: Reboot_system
+  ansible.builtin.reboot:
+    pre_reboot_delay: 15

--- a/roles/uninstall/tasks/main.yml
+++ b/roles/uninstall/tasks/main.yml
@@ -10,6 +10,7 @@
   failed_when:
     - k3s_service_present.failed
     - "'Could not find the requested service' not in k3s_service_present.msg"
+  notify: Reboot_system
 
 - name: Run the default k3s-killall.sh script from rancher # noqa: command-instead-of-shell
   ansible.builtin.shell: "{{ lookup('file', 'k3s-killall.sh') }}"


### PR DESCRIPTION
This PR will swap back using the kube-vip loadbalancer IP (if set) for the server variable.

Moreover when uninstalling k3s the system will be rebooted to reset the network stack when the loadbalancer ip was assigned to the node.